### PR TITLE
Enable Windows Test on PR

### DIFF
--- a/.github/workflows/test-win-exe-w-embed-py.yaml
+++ b/.github/workflows/test-win-exe-w-embed-py.yaml
@@ -2,6 +2,8 @@ name: Test streamlit executable for Windows with embeddable python
 on: 
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -116,7 +118,7 @@ jobs:
           <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
             <Product Id="8434b940-a943-40f1-ab1f-4db3feedb4ba" Name="${{ env.APP_NAME }}" Language="1033" Version="1.0.0.0" Codepage="1252" Manufacturer="OpenMS Developer Team" UpgradeCode="8d28e8c7-45dc-446c-b889-99a6aea2f1a5">
               <Package Id="*" InstallerVersion="300" Compressed="yes" InstallPrivileges="elevated" Platform="x64" />
-              <Media Id="1" Cabinet="streamlit.cab" EmbedCab="yes" />
+              <MediaTemplate EmbedCab="yes" />
           
               <!-- Folder structure -->
               <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
@@ -191,7 +193,7 @@ jobs:
           
       - name: Link .wixobj file into .msi with light.exe
         run: |
-          ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj
+          ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj -b SourceDir
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR applies to fixes from #19 to the windows installer tests and enables the GA on PR to main. Long term we should probably combine the test and build GAs. I will prepare a PR for the template.