### PR TITLE
Fix Parameter Summary

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -1125,7 +1125,7 @@ class StreamlitUI:
         )
         version = ""
         if result.returncode == 0:
-            version = result.stderr.split("Version: ")[1].split("-")[0]
+            version = result.stderr.split("Version: ")[1][:5]
 
         markdown.append(
             f"""Data was processed using **{st.session_state.settings['app-name']}** ([{url}]({url})), a web application based on the OpenMS WebApps framework [1].


### PR DESCRIPTION
Relying on the `-` to distinguish the version from the following help text is not reliable as for releases it might be replaced by a space. Thus I suggest to detect the length using a fixed size. Should be more reliable as long as we dont change the way we are doing major and minor releases.